### PR TITLE
Mark OpenDataParserApplication as open

### DIFF
--- a/src/main/kotlin/com/ist/curriculum/opendataparser/OpenDataParserApplication.kt
+++ b/src/main/kotlin/com/ist/curriculum/opendataparser/OpenDataParserApplication.kt
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 
 @SpringBootApplication
-class OpenDataParserApplication
+open class OpenDataParserApplication
 
 fun main(args: Array<String>) {
     SpringApplication.run(OpenDataParserApplication::class.java, *args)


### PR DESCRIPTION
Fixes the following issue when running:

> Configuration problem: @Configuration class 'OpenDataParserApplication' may not be final. Remove the final modifier to continue.