### PR TITLE
Strong split

### DIFF
--- a/src/main/kotlin/org/edtech/curriculum/TextUtils.kt
+++ b/src/main/kotlin/org/edtech/curriculum/TextUtils.kt
@@ -28,8 +28,13 @@ private fun splitWords(line: String): List<String> {
  * where 1 is representing the exact same line and 0 when the lines has nothing incommon
  */
 fun similarLineRatio(line1: String, line2:String): Double {
-    val wordList1  = removeInflections(splitWords(removeBoldWords(line1.toLowerCase())))
-    val wordList2  = removeInflections(splitWords(removeBoldWords(line2.toLowerCase())))
+    var wordList1  = removeInflections(splitWords(removeBoldWords(line1.toLowerCase())))
+    var wordList2  = removeInflections(splitWords(removeBoldWords(line2.toLowerCase())))
+
+    if(wordList1.isEmpty())
+        wordList1 = removeInflections(splitWords(removeBoldTags(line1.toLowerCase())))
+    if(wordList2.isEmpty())
+        wordList2 = removeInflections(splitWords(removeBoldTags(line2.toLowerCase())))
 
     if (wordList2.isEmpty() || wordList1.isEmpty()) {
         return 0.0
@@ -71,4 +76,13 @@ internal fun removeBoldWords(htmlText: String): String {
             .replace(Regex("<strong>[^>]* </strong>"), " ")
             .replace(Regex("<strong>[^>]*</strong>"), "")
             .replace(Regex("[ ][ ]+"),  " ")
+}
+
+/**
+ * Removes all bold tags
+ */
+internal fun removeBoldTags(htmlText: String): String {
+    return htmlText
+            .replace(Regex("</?strong>"), "")
+            .replace(Regex("[ ][ ]+"), " ")
 }

--- a/src/main/kotlin/org/edtech/curriculum/internal/HtmlUtils.kt
+++ b/src/main/kotlin/org/edtech/curriculum/internal/HtmlUtils.kt
@@ -42,7 +42,7 @@ internal fun fixCurriculumErrors(text: String): String {
             // Remove double spacing
             .replace(Regex("[ ][ ]+"),  " ")
             .replace("<strong> ",  " <strong>")
-            .replace(" </strong>",  "</strong> ")
+            .replace(Regex("([. ]+)</strong>"),  "</strong>$1")
             .trim()
 }
 

--- a/src/test/kotlin/org/edtech/curriculum/internal/KnowledgeRequirementParserTest.kt
+++ b/src/test/kotlin/org/edtech/curriculum/internal/KnowledgeRequirementParserTest.kt
@@ -163,12 +163,13 @@ class KnowledgeRequirementParserTest {
                 if (!hasMissingRequirementsFromSkolverket.contains(course.code)) {
                     course.knowledgeRequirementParagraphs.forEach {
                         it.knowledgeRequirements.forEach {
-                            if (!it.knowledgeRequirementChoice.keys.containsAll(setOf(GradeStep.E, GradeStep.C, GradeStep.E)) &&
-                                    !it.knowledgeRequirementChoice.keys.contains(GradeStep.G)) {
+                            val gradeSteps = it.knowledgeRequirementChoice
+                            if (!gradeSteps.keys.containsAll(setOf(GradeStep.A, GradeStep.C, GradeStep.E)) &&
+                                    !gradeSteps.keys.contains(GradeStep.G)) {
                                 fail("Knowledge Requirement Choices should be either E,C,A or G failed for: ${subject.name}/${course.name}")
                             }
-                            it.knowledgeRequirementChoice.forEach {
-                                if (it.value.isBlank())
+                            gradeSteps.forEach { gradeStep ->
+                                if (gradeStep.value.isBlank())
                                     fail("Found empty knowledge requirement critera in ${subject.name}/${course.name} [${course.code}]")
                             }
                         }

--- a/src/test/resources/valid/GRS/GRSAMAT01.json
+++ b/src/test/resources/valid/GRS/GRSAMAT01.json
@@ -95,15 +95,15 @@
         "text" : "Eleven uppskattar, mäter och avläser sträckor, massor och volymer och <strong>________</strong> till att storleksordna enheterna.",
         "knowledgeRequirementChoice" : {
           "E" : "Eleven uppskattar, mäter och avläser sträckor, massor och volymer och <strong>bidrar</strong> till att storleksordna enheterna.",
-          "C" : "Eleven uppskattar, mäter och avläser sträckor, massor och volymer och storleksordnar enheterna med <strong>viss säkerhet.",
-          "A" : "Eleven uppskattar, mäter och avläser sträckor, massor och volymer och storleksordnar enheterna med <strong>säkerhet."
+          "C" : "Eleven uppskattar, mäter och avläser sträckor, massor och volymer och storleksordnar enheterna med <strong>viss säkerhet</strong>.",
+          "A" : "Eleven uppskattar, mäter och avläser sträckor, massor och volymer och storleksordnar enheterna med <strong>säkerhet</strong>."
         }
       }, {
         "text" : "Eleven kan <strong>________</strong> till resonemang om rimlighet när det gäller priser, mängder, tider och annan matematisk information.",
         "knowledgeRequirementChoice" : {
           "E" : "Eleven kan <strong>bidra</strong> till resonemang om rimlighet när det gäller priser, mängder, tider och annan matematisk information.",
-          "C" : "</strong> Eleven kan föra <strong>enkla</strong> och <strong>till viss del underbyggda</strong> resonemang om rimlighet när det gäller priser, mängder, tider och annan matematisk information.",
-          "A" : "</strong> Eleven kan föra <strong>välutvecklade</strong> och <strong>väl underbyggda</strong> resonemang om rimlighet när det gäller priser, mängder, tider och annan matematisk information."
+          "C" : "Eleven kan föra <strong>enkla</strong> och <strong>till viss del underbyggda</strong> resonemang om rimlighet när det gäller priser, mängder, tider och annan matematisk information.",
+          "A" : "Eleven kan föra <strong>välutvecklade</strong> och <strong>väl underbyggda</strong> resonemang om rimlighet när det gäller priser, mängder, tider och annan matematisk information."
         }
       }, {
         "text" : "Eleven <strong>________</strong> också till omdömen om rimlighet i egna och andras beräkningar och lösningar.",
@@ -196,15 +196,15 @@
         "text" : "Eleven uppskattar, mäter och avläser sträckor, massor och volymer och <strong>________</strong> till att storleksordna enheterna.",
         "knowledgeRequirementChoice" : {
           "E" : "Eleven uppskattar, mäter och avläser sträckor, massor och volymer och <strong>bidrar</strong> till att storleksordna enheterna.",
-          "C" : "Eleven uppskattar, mäter och avläser sträckor, massor och volymer och storleksordnar enheterna med <strong>viss säkerhet.",
-          "A" : "Eleven uppskattar, mäter och avläser sträckor, massor och volymer och storleksordnar enheterna med <strong>säkerhet."
+          "C" : "Eleven uppskattar, mäter och avläser sträckor, massor och volymer och storleksordnar enheterna med <strong>viss säkerhet</strong>.",
+          "A" : "Eleven uppskattar, mäter och avläser sträckor, massor och volymer och storleksordnar enheterna med <strong>säkerhet</strong>."
         }
       }, {
         "text" : "Eleven kan <strong>________</strong> till resonemang om rimlighet när det gäller priser, mängder, tider och annan matematisk information.",
         "knowledgeRequirementChoice" : {
           "E" : "Eleven kan <strong>bidra</strong> till resonemang om rimlighet när det gäller priser, mängder, tider och annan matematisk information.",
-          "C" : "</strong> Eleven kan föra <strong>enkla</strong> och <strong>till viss del underbyggda</strong> resonemang om rimlighet när det gäller priser, mängder, tider och annan matematisk information.",
-          "A" : "</strong> Eleven kan föra <strong>välutvecklade</strong> och <strong>väl underbyggda</strong> resonemang om rimlighet när det gäller priser, mängder, tider och annan matematisk information."
+          "C" : "Eleven kan föra <strong>enkla</strong> och <strong>till viss del underbyggda</strong> resonemang om rimlighet när det gäller priser, mängder, tider och annan matematisk information.",
+          "A" : "Eleven kan föra <strong>välutvecklade</strong> och <strong>väl underbyggda</strong> resonemang om rimlighet när det gäller priser, mängder, tider och annan matematisk information."
         }
       }, {
         "text" : "Eleven <strong>________</strong> också till omdömen om rimlighet i egna och andras beräkningar och lösningar.",

--- a/src/test/resources/valid/GY/HAV.json
+++ b/src/test/resources/valid/GY/HAV.json
@@ -281,7 +281,7 @@
         "knowledgeRequirementChoice" : {
           "E" : "Eleven arbetar på ett ergonomiskt riktigt sätt och använder skyddsutrustning och lämpliga arbetskläder.",
           "C" : "Eleven arbetar på ett ergonomiskt riktigt sätt och använder skyddsutrustning och lämpliga arbetskläder. <strong>Eleven utvärderar sin egen arbetsmiljö med enkla omdömen samt ger välgrundade förslag på förbättringar av arbetsmiljön</strong>.",
-          "A" : "Eleven arbetar på ett ergonomiskt riktigt sätt och använder skyddsutrustning och lämpliga arbetskläder. <strong>Eleven utvärderar sin egen arbetsmiljö med nyanserade omdömen samt ger välgrundade och nyanserade förslag på förbättringar av arbetsmiljön och hur hon eller han själv kan bidra till dessa. </strong>"
+          "A" : "Eleven arbetar på ett ergonomiskt riktigt sätt och använder skyddsutrustning och lämpliga arbetskläder. <strong>Eleven utvärderar sin egen arbetsmiljö med nyanserade omdömen samt ger välgrundade och nyanserade förslag på förbättringar av arbetsmiljön och hur hon eller han själv kan bidra till dessa</strong>."
         }
       } ]
     }, {

--- a/src/test/resources/valid/GY/MOD.json
+++ b/src/test/resources/valid/GY/MOD.json
@@ -719,14 +719,14 @@
         "knowledgeRequirementChoice" : {
           "E" : "I muntliga framställningar av olika slag formulerar sig eleven enkelt, <strong>begripligt och till viss del</strong> sammanhängande.",
           "C" : "I muntliga framställningar av olika slag formulerar sig eleven enkelt, <strong>relativt tydligt och relativt</strong> sammanhängande.",
-          "A" : "I muntliga framställningar av olika slag formulerar sig eleven enkelt, <strong>relativt varierat, tydligt och relativt</strong> sammanhängande. <strong>Eleven formulerar sig även med visst flyt och i någon mån anpassat till syfte, mottagare och situation."
+          "A" : "I muntliga framställningar av olika slag formulerar sig eleven enkelt, <strong>relativt varierat, tydligt och relativt</strong> sammanhängande. <strong>Eleven formulerar sig även med visst flyt och i någon mån anpassat till syfte, mottagare och situation</strong>."
         }
       }, {
         "text" : "För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>________</strong> förbättringar av, egna framställningar.",
         "knowledgeRequirementChoice" : {
           "E" : "För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>enkla</strong> förbättringar av, egna framställningar.",
           "C" : "För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>enkla</strong> förbättringar av, egna framställningar.",
-          "A" : "</strong> För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>välgrundade</strong> förbättringar av, egna framställningar."
+          "A" : "För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>välgrundade</strong> förbättringar av, egna framställningar."
         }
       } ]
     }, {
@@ -904,14 +904,14 @@
         "knowledgeRequirementChoice" : {
           "E" : "I muntliga framställningar av olika slag formulerar sig eleven <strong>enkelt, begripligt</strong> och relativt sammanhängande.",
           "C" : "I muntliga framställningar av olika slag formulerar sig eleven <strong>relativt tydligt</strong> och relativt sammanhängande.",
-          "A" : "I muntliga framställningar av olika slag formulerar sig eleven <strong>relativt varierat, tydligt</strong> och relativt sammanhängande. <strong>Eleven formulerar sig även med visst flyt och i någon mån anpassat till syfte, mottagare och situation."
+          "A" : "I muntliga framställningar av olika slag formulerar sig eleven <strong>relativt varierat, tydligt</strong> och relativt sammanhängande. <strong>Eleven formulerar sig även med visst flyt och i någon mån anpassat till syfte, mottagare och situation</strong>."
         }
       }, {
         "text" : "För att förtydliga och variera sin kommunikation bearbetar eleven egna framställningar och gör <strong>________</strong> förbättringar.",
         "knowledgeRequirementChoice" : {
           "E" : "För att förtydliga och variera sin kommunikation bearbetar eleven egna framställningar och gör <strong>enkla</strong> förbättringar.",
           "C" : "För att förtydliga och variera sin kommunikation bearbetar eleven egna framställningar och gör <strong>välgrundade</strong> förbättringar.",
-          "A" : "</strong> För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>välgrundade</strong> förbättringar."
+          "A" : "För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>välgrundade</strong> förbättringar."
         }
       } ]
     }, {
@@ -982,14 +982,14 @@
         "knowledgeRequirementChoice" : {
           "E" : "I skriftliga framställningar med förenklade tecken formulerar sig eleven enkelt och <strong>begripligt</strong> och <strong>till viss del</strong> sammanhängande.",
           "C" : "I skriftliga framställningar med förenklade tecken formulerar sig eleven enkelt, <strong>relativt tydligt</strong> och <strong>till viss del</strong> sammanhängande.",
-          "A" : "I skriftliga framställningar med förenklade tecken formulerar sig eleven enkelt, <strong>relativt tydligt</strong> och <strong>relativt</strong> sammanhängande. <strong>Eleven formulerar sig även i någon mån anpassat till syfte, mottagare och situation."
+          "A" : "I skriftliga framställningar med förenklade tecken formulerar sig eleven enkelt, <strong>relativt tydligt</strong> och <strong>relativt</strong> sammanhängande. <strong>Eleven formulerar sig även i någon mån anpassat till syfte, mottagare och situation</strong>."
         }
       }, {
         "text" : "För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>________</strong> förbättringar.",
         "knowledgeRequirementChoice" : {
           "E" : "För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>enkla</strong> förbättringar.",
           "C" : "För att förtydliga och variera sin kommunikation bearbetar eleven egna framställningar och gör <strong>enkla</strong> förbättringar.",
-          "A" : "</strong> För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>välgrundade</strong> förbättringar."
+          "A" : "För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>välgrundade</strong> förbättringar."
         }
       } ]
     }, {
@@ -1088,15 +1088,15 @@
         "text" : "I muntliga framställningar i olika genrer formulerar sig eleven <strong>________</strong> och <strong>________</strong> sammanhängande.",
         "knowledgeRequirementChoice" : {
           "E" : "I muntliga framställningar i olika genrer formulerar sig eleven <strong>enkelt, begripligt</strong> och <strong>relativt</strong> sammanhängande.",
-          "C" : "I muntliga framställningar i olika genrer formulerar sig eleven <strong>relativt varierat, relativt tydligt</strong> och <strong>relativt</strong> sammanhängande. <strong>Eleven formulerar sig även med visst flyt och i någon mån anpassat till syfte, mottagare och situation.",
-          "A" : "I muntliga framställningar i olika genrer formulerar sig eleven <strong>relativt varierat, tydligt</strong> och sammanhängande. <strong>Eleven formulerar sig även med flyt och med viss anpassning till syfte, mottagare och situation."
+          "C" : "I muntliga framställningar i olika genrer formulerar sig eleven <strong>relativt varierat, relativt tydligt</strong> och <strong>relativt</strong> sammanhängande. <strong>Eleven formulerar sig även med visst flyt och i någon mån anpassat till syfte, mottagare och situation</strong>.",
+          "A" : "I muntliga framställningar i olika genrer formulerar sig eleven <strong>relativt varierat, tydligt</strong> och sammanhängande. <strong>Eleven formulerar sig även med flyt och med viss anpassning till syfte, mottagare och situation</strong>."
         }
       }, {
         "text" : "För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>________</strong> förbättringar.",
         "knowledgeRequirementChoice" : {
           "E" : "För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>enkla</strong> förbättringar.",
-          "C" : "</strong> För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>välgrundade</strong> förbättringar.",
-          "A" : "</strong> För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>välgrundade</strong> förbättringar."
+          "C" : "För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>välgrundade</strong> förbättringar.",
+          "A" : "För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>välgrundade</strong> förbättringar."
         }
       } ]
     }, {
@@ -1167,14 +1167,14 @@
         "knowledgeRequirementChoice" : {
           "E" : "I skriftliga framställningar med förenklade tecken formulerar sig eleven <strong>enkelt, begripligt och till viss del</strong> sammanhängande.",
           "C" : "I skriftliga framställningar med förenklade tecken formulerar sig eleven <strong>enkelt, relativt tydligt och relativt</strong> sammanhängande.",
-          "A" : "I skriftliga framställningar med förenklade tecken formulerar sig eleven <strong>relativt varierat, tydligt och relativt</strong> sammanhängande. <strong>Eleven formulerar sig även med visst flyt och i någon mån anpassat till syfte, mottagare och situation."
+          "A" : "I skriftliga framställningar med förenklade tecken formulerar sig eleven <strong>relativt varierat, tydligt och relativt</strong> sammanhängande. <strong>Eleven formulerar sig även med visst flyt och i någon mån anpassat till syfte, mottagare och situation</strong>."
         }
       }, {
         "text" : "För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>________</strong> förbättringar.",
         "knowledgeRequirementChoice" : {
           "E" : "För att förtydliga och variera sin kommunikation, bearbetar eleven egna framställningar och gör <strong>enkla</strong> förbättringar.",
           "C" : "För att förtydliga och variera sin kommunikation bearbetar eleven egna framställningar och gör <strong>enkla</strong> förbättringar.",
-          "A" : "</strong> För att förtydliga och variera sin kommunikation bearbetar eleven egna framställningar och gör <strong>välgrundade</strong> förbättringar."
+          "A" : "För att förtydliga och variera sin kommunikation bearbetar eleven egna framställningar och gör <strong>välgrundade</strong> förbättringar."
         }
       } ]
     }, {
@@ -1470,14 +1470,14 @@
         "knowledgeRequirementChoice" : {
           "E" : "I muntliga och skriftliga framställningar av olika slag formulerar sig eleven <strong>enkelt, begripligt och till viss del</strong> sammanhängande.",
           "C" : "I muntliga och skriftliga framställningar av olika slag formulerar sig eleven <strong>enkelt, relativt tydligt och relativt</strong> sammanhängande.",
-          "A" : "I muntliga och skriftliga framställningar av olika slag formulerar sig eleven <strong>relativt varierat, tydligt och relativt</strong> sammanhängande. <strong>Eleven formulerar sig även med visst flyt och i någon mån anpassat till syfte, mottagare och situation."
+          "A" : "I muntliga och skriftliga framställningar av olika slag formulerar sig eleven <strong>relativt varierat, tydligt och relativt</strong> sammanhängande. <strong>Eleven formulerar sig även med visst flyt och i någon mån anpassat till syfte, mottagare och situation</strong>."
         }
       }, {
         "text" : "För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>________</strong> förbättringar av, egna framställningar.",
         "knowledgeRequirementChoice" : {
           "E" : "För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>enkla</strong> förbättringar av, egna framställningar.",
           "C" : "För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>enkla</strong> förbättringar av, egna framställningar.",
-          "A" : "</strong> För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>välgrundade</strong> förbättringar av, egna framställningar."
+          "A" : "För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>välgrundade</strong> förbättringar av, egna framställningar."
         }
       } ]
     }, {
@@ -1570,15 +1570,15 @@
         "text" : "I muntliga och skriftliga framställningar i olika genrer formulerar sig eleven <strong>________</strong> och <strong>________</strong> sammanhängande.",
         "knowledgeRequirementChoice" : {
           "E" : "I muntliga och skriftliga framställningar i olika genrer formulerar sig eleven <strong>enkelt, begripligt</strong> och <strong>relativt</strong> sammanhängande.",
-          "C" : "I muntliga och skriftliga framställningar i olika genrer formulerar sig eleven <strong>relativt varierat, relativt tydligt</strong> och <strong>relativt</strong> sammanhängande. <strong>Eleven formulerar sig även med visst flyt och i någon mån anpassat till syfte, mottagare och situation.",
-          "A" : "I muntliga och skriftliga framställningar i olika genrer formulerar sig eleven <strong>relativt varierat, tydligt</strong> och sammanhängande. <strong>Eleven formulerar sig även med flyt och viss anpassning till syfte, mottagare och situation."
+          "C" : "I muntliga och skriftliga framställningar i olika genrer formulerar sig eleven <strong>relativt varierat, relativt tydligt</strong> och <strong>relativt</strong> sammanhängande. <strong>Eleven formulerar sig även med visst flyt och i någon mån anpassat till syfte, mottagare och situation</strong>.",
+          "A" : "I muntliga och skriftliga framställningar i olika genrer formulerar sig eleven <strong>relativt varierat, tydligt</strong> och sammanhängande. <strong>Eleven formulerar sig även med flyt och viss anpassning till syfte, mottagare och situation</strong>."
         }
       }, {
         "text" : "För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>________</strong> förbättringar av, egna framställningar.",
         "knowledgeRequirementChoice" : {
           "E" : "För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>enkla</strong> förbättringar av, egna framställningar.",
-          "C" : "</strong> För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>välgrundade</strong> förbättringar av, egna framställningar.",
-          "A" : "</strong> För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>välgrundade</strong> förbättringar av, egna framställningar."
+          "C" : "För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>välgrundade</strong> förbättringar av, egna framställningar.",
+          "A" : "För att förtydliga och variera sin kommunikation bearbetar eleven, och gör <strong>välgrundade</strong> förbättringar av, egna framställningar."
         }
       } ]
     }, {

--- a/src/test/resources/valid/VUXGR/GRNBIO2.json
+++ b/src/test/resources/valid/VUXGR/GRNBIO2.json
@@ -55,14 +55,14 @@
         "text" : "I diskussionerna ställer eleven frågor och framför och bemöter åsikter och argument på ett sätt som <strong>________</strong>.",
         "knowledgeRequirementChoice" : {
           "E" : "I diskussionerna ställer eleven frågor och framför och bemöter åsikter och argument på ett sätt som <strong>till viss del för diskussionerna framåt</strong>.",
-          "C" : "I diskussionerna ställer eleven frågor och framför och bemöter åsikter och argument på ett sätt som <strong>för diskussionerna framåt.",
+          "C" : "I diskussionerna ställer eleven frågor och framför och bemöter åsikter och argument på ett sätt som <strong>för diskussionerna framåt</strong>.",
           "A" : "I diskussionerna ställer eleven frågor och framför och bemöter åsikter och argument på ett sätt som för <strong>diskussionerna framåt och fördjupar eller breddar dem</strong>."
         }
       }, {
         "text" : "Eleven kan söka naturvetenskaplig information och använder då olika källor och för <strong>________</strong> resonemang om informationens och källornas trovärdighet och relevans.",
         "knowledgeRequirementChoice" : {
           "E" : "Eleven kan söka naturvetenskaplig information och använder då olika källor och för <strong>enkla och till viss del underbyggda</strong> resonemang om informationens och källornas trovärdighet och relevans.",
-          "C" : "</strong> Eleven kan söka naturvetenskaplig information och använder då olika källor och för <strong>utvecklade och relativt väl underbyggda</strong> resonemang om informationens och källornas trovärdighet och relevans.",
+          "C" : "Eleven kan söka naturvetenskaplig information och använder då olika källor och för <strong>utvecklade och relativt väl underbyggda</strong> resonemang om informationens och källornas trovärdighet och relevans.",
           "A" : "Eleven kan söka naturvetenskaplig information och använder då olika källor och för <strong>välutvecklade och väl underbyggda</strong> resonemang om informationens och källornas trovärdighet och relevans."
         }
       }, {


### PR DESCRIPTION
Hoppas lösa #26 och #27 

Det började med att jag flyttade ut punkter från strong-taggarna för att meningarna inte skulle bryta mitt i strong taggarna. Då uppdagades problemet att det finns rader där hela meningen är innanför strong. Det gör i sin tur att similarLineRatio blir ledsen för att raden inte har några ord kvar efter man plockat bort allt innanför strong.
För att försöka råda bot på det tar jag bara bort strong taggarna om raden inte har några ord kvar. Vad tror du om den här lösningen? Det bästa vore ju om skolverket kunde rätta till texten i #27 