### PR TITLE
Remove blank core content rows, add test for it

### DIFF
--- a/src/main/kotlin/org/edtech/curriculum/internal/CentralContentConverter.kt
+++ b/src/main/kotlin/org/edtech/curriculum/internal/CentralContentConverter.kt
@@ -21,18 +21,16 @@ class CentralContentConverter {
                 .select("body > *:not(:empty)")
                 .mapNotNull {
                     if (it.tagName() == "ul") {
-                        if (it.previousElementSibling() != null) {
-                            CentralContent(it.previousElementSibling().text(), it.children().map { it.text() })
-                        } else {
-                            CentralContent("",  it.children().map { it.text() })
-                        }
+                        val lines = it.children().map { it.text() }.filter { it.isNotBlank() }.map { it.trim() }
+                        val heading = it.previousElementSibling()?.text()?.trim() ?: ""
+                        CentralContent(heading, lines)
                     } else {
                         // Just a heading
-                        if (it.nextElementSibling() != null && it.nextElementSibling().tagName() == "ul") {
+                        if (it.nextElementSibling()?.tagName() == "ul") {
                             null
                         } else {
                             // Heading before
-                            CentralContent(it.text(),  listOf())
+                            CentralContent(it.text().trim(), listOf())
                         }
                     }
                 })

--- a/src/test/kotlin/org/edtech/curriculum/internal/CentralContentConverterTest.kt
+++ b/src/test/kotlin/org/edtech/curriculum/internal/CentralContentConverterTest.kt
@@ -75,4 +75,13 @@ internal class CentralContentConverterTest {
                         "<p>– Lekar och musik från områden där modersmålet talas.</p>")
         )
     }
+
+    @Test
+    fun testEmptyLines() {
+        val centralContents = CentralContentConverter().getCentralContents("<h4> Testar tomma rader  </h4><ul><li>Rad 1</li><li></li><li>  Rad 2 </li> <li> </li>")
+        Assert.assertEquals(1, centralContents.size)
+        Assert.assertEquals("Testar tomma rader", centralContents[0].heading)
+        Assert.assertEquals(2, centralContents[0].lines.size)
+        Assert.assertEquals("Rad 2", centralContents[0].lines[1])
+    }
 }


### PR DESCRIPTION
Found a blank core content line in `Moderna språk för döva och hörselskadade` i specialskolan
`GRSPMSP01_5-10-WITHIN_STUDENT_CHOICE` under `Läsa och/eller lyssna – reception`